### PR TITLE
added raids command and support for types

### DIFF
--- a/app/models/raid.rb
+++ b/app/models/raid.rb
@@ -28,12 +28,16 @@ class Raid < ActiveRecord::Base
   end
 
   # Returns first raid of the passed types (or of each type if none are passed)
-  def self.raid_info(guild_uid, types = Raid.raid_types.values, time = Time.zone.now)
+  def self.raid_info(guild_uid, types, return_all = false, time = Time.zone.now)
+    types = types || Raid.raid_types.values
+
     guild = Guild.where(uid: guild_uid).first
     raids = joins(:phases).order('phases.start ASC')
               .where('phases.start > ?', time - 9.hours)
               .where(raid_type: types)
               .where(guild_id: guild.id)
+    return raids.all if return_all
+
     types.map do |type|
       result = raids.select { |raid| raid.raid_type == Raid.raid_types.keys[type] }
       next if result.blank?

--- a/lib/bot/discord/omega/omega_bot.rb
+++ b/lib/bot/discord/omega/omega_bot.rb
@@ -10,9 +10,14 @@ module Bot::Discord::Omega
         event.respond 'All hail the bearded warrior!'
       end
 
-      command_bot.command(:raid, description: raid_command_description) do |event|
+      command_bot.command(:raid, description: raid_command_description) do |event, type|
         return unless Rails.env.production? || event.server.name == 'Test'
-        raid_info(event.server.id)
+        raid_info(event.server.id, type ? [type.to_sym] : nil)
+      end
+
+      command_bot.command(:raids, description: raid_command_description) do |event, type|
+        return unless Rails.env.production? || event.server.name == 'Test'
+        raid_info(event.server.id, type ? [type.to_sym] : nil, return_all = true)
       end
 
       @bot.run :async
@@ -40,9 +45,9 @@ module Bot::Discord::Omega
 
     private
 
-    def raid_info(guild_uid)
+    def raid_info(guild_uid, types, return_all = false)
       message = ''
-      Raid.raid_info(guild_uid).each do |raid|
+      Raid.raid_info(guild_uid, types, return_all).each do |raid|
         message += "\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" unless message.empty?
         message += "**Raid: #{raid.display}**"
 
@@ -72,7 +77,11 @@ module Bot::Discord::Omega
     end
 
     def raid_command_description
-      'Shows time until next raid (including all phases) in hours/minutes'
+      'Shows time until next raid (including all phases) in hours/minutes\nPass type to get specific raid (ex. !raid pit, !raid tank)'
+    end
+
+    def raids_command_description
+      'Shows time for all current/future raids (including all phases) in hours/minutes\nPass type to get specific raids (ex. !raids pit, !raids tank)'
     end
   end
 end

--- a/spec/models/raid_spec.rb
+++ b/spec/models/raid_spec.rb
@@ -75,6 +75,11 @@ RSpec.describe Raid, type: :model do
       expect(Raid.raid_info(guild.uid, types = [1])).to eq [tank_raids.first]
     end
 
+    it 'returns all raids of the passed type if return_all is true' do
+      expect(Raid.raid_info(guild.uid, types = [0], return_all = true)).to eq pit_raids
+      expect(Raid.raid_info(guild.uid, types = [1], return_all = true)).to eq tank_raids
+    end
+
     context 'one of the raids was in the near past (less than 9 hours ago)' do
       let(:start) { Time.zone.now - 9.hours } # raid will have one phase 9 hours ago and another 8 hours ago
 


### PR DESCRIPTION
Added optional raid type argument to `!raid` command. Can be `pit` or `tank` (can add more when needed).
Added `!raids` command to return all the current/future raids. Can also take type parameter.